### PR TITLE
Add filter version lists and change resolver method to dedicated repo list

### DIFF
--- a/.github/workflows/auto-run.yml
+++ b/.github/workflows/auto-run.yml
@@ -11,7 +11,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: iffy/install-nim@v4
-      - run: nim -r c -d:ssl ./scraper.nim
+      - run: nim -r c ./scraper.nim
       - run: rm ./scraper
       - run: rm -rf ./Repos
       - name: commit

--- a/repos.json
+++ b/repos.json
@@ -1,0 +1,23 @@
+{
+  "known_repos": [
+    "github.com/Bedrock-OSS/regolith-filters",
+    "github.com/Hatchibombotar/useful-regolith-filters",
+    "github.com/MCDevKit/regolith-library",
+    "github.com/MajestikButter/Regolith-Filters",
+    "github.com/Makercamp-SRLs/Regolith-filters",
+    "github.com/MedicalJewel105/regolilters",
+    "github.com/Nusiq/regolith-filters",
+    "github.com/ShiCheng-Lu/Regolith-Filters",
+    "github.com/SirLich/echo-npc-regolith",
+    "github.com/SirLich/regolith-filters",
+    "github.com/SmokeyStack/MCScripts",
+    "github.com/cda94581/regolith-filters",
+    "github.com/cda94581/regolith-premade-addons",
+    "github.com/evilguy50/my-regolith-filters",
+    "github.com/ink0rr/regolith-filters",
+    "github.com/littlechestnutgames/regolith-filters",
+    "github.com/SmokeyStack/adk",
+    "github.com/llgava/regolith-filters",
+    "github.com/Bedrock-OSS/regolith-filters"
+  ]
+}

--- a/resolver.json
+++ b/resolver.json
@@ -198,6 +198,9 @@
     },
     "json_convert": {
       "url": "github.com/Bedrock-OSS/regolith-filters"
+    },
+    "cda94581_export": {
+      "url": "github.com/cda94581/regolith-filters"
     }
   }
 }

--- a/resolver.json
+++ b/resolver.json
@@ -1,206 +1,668 @@
 {
-  "formatVersion": "1.0.0",
+  "formatVersion": "1.1.0",
   "filters": {
     "blockbench_convert": {
-      "url": "github.com/Bedrock-OSS/regolith-filters"
+      "url": "github.com/Bedrock-OSS/regolith-filters",
+      "versions": [
+        "latest",
+        "1.0.0",
+        "1.1.0"
+      ]
     },
     "bump_manifest": {
-      "url": "github.com/Bedrock-OSS/regolith-filters"
+      "url": "github.com/Bedrock-OSS/regolith-filters",
+      "versions": [
+        "latest",
+        "1.0.0"
+      ]
     },
     "filter_tester": {
-      "url": "github.com/Bedrock-OSS/regolith-filters"
+      "url": "github.com/Bedrock-OSS/regolith-filters",
+      "versions": [
+        "latest",
+        "1.0.0"
+      ]
     },
     "fix_emissive": {
-      "url": "github.com/Bedrock-OSS/regolith-filters"
+      "url": "github.com/Bedrock-OSS/regolith-filters",
+      "versions": [
+        "latest",
+        "1.0.0"
+      ]
     },
     "gametests": {
-      "url": "github.com/Bedrock-OSS/regolith-filters"
+      "url": "github.com/Bedrock-OSS/regolith-filters",
+      "versions": [
+        "latest",
+        "1.0.0",
+        "1.0.1",
+        "1.0.2",
+        "1.0.3",
+        "1.1.0",
+        "1.2.0",
+        "1.3.0",
+        "1.3.1",
+        "1.3.2",
+        "1.3.3"
+      ]
     },
     "json_cleaner": {
-      "url": "github.com/Bedrock-OSS/regolith-filters"
+      "url": "github.com/Bedrock-OSS/regolith-filters",
+      "versions": [
+        "latest",
+        "1.0.0",
+        "1.1.0",
+        "1.1.1"
+      ]
     },
     "name_ninja": {
-      "url": "github.com/Bedrock-OSS/regolith-filters"
+      "url": "github.com/Bedrock-OSS/regolith-filters",
+      "versions": [
+        "latest",
+        "1.0.0",
+        "1.1.0",
+        "1.2.0",
+        "1.2.1",
+        "1.2.2",
+        "1.2.3"
+      ]
     },
     "texture_convert": {
-      "url": "github.com/Bedrock-OSS/regolith-filters"
+      "url": "github.com/Bedrock-OSS/regolith-filters",
+      "versions": [
+        "latest",
+        "1.0.0",
+        "1.1.0",
+        "1.1.1"
+      ]
     },
     "texture_list": {
-      "url": "github.com/Bedrock-OSS/regolith-filters"
+      "url": "github.com/Bedrock-OSS/regolith-filters",
+      "versions": [
+        "latest",
+        "1.0.0",
+        "1.1.0",
+        "1.1.1",
+        "1.1.2"
+      ]
     },
     "debug_log": {
-      "url": "github.com/Hatchibombotar/useful-regolith-filters"
+      "url": "github.com/Hatchibombotar/useful-regolith-filters",
+      "versions": [
+        "latest",
+        "0.0.1",
+        "0.0.2"
+      ]
     },
     "file_freedom": {
-      "url": "github.com/Hatchibombotar/useful-regolith-filters"
+      "url": "github.com/Hatchibombotar/useful-regolith-filters",
+      "versions": [
+        "latest",
+        "1.0.0",
+        "1.0.1",
+        "1.1.0",
+        "1.1.1",
+        "1.1.2",
+        "1.1.3",
+        "1.1.4",
+        "1.1.5",
+        "1.1.6",
+        "1.2.0",
+        "1.2.1",
+        "1.2.2",
+        "1.2.3",
+        "1.2.4",
+        "1.2.5",
+        "1.2.6",
+        "1.2.7",
+        "1.2.8",
+        "1.2.9",
+        "1.3.0"
+      ]
     },
     "functioner": {
-      "url": "github.com/Hatchibombotar/useful-regolith-filters"
+      "url": "github.com/Hatchibombotar/useful-regolith-filters",
+      "versions": [
+        "latest",
+        "0.0.1",
+        "1.0.0",
+        "1.1.0",
+        "1.2.0",
+        "1.2.1",
+        "1.2.2",
+        "1.3.0",
+        "1.3.1",
+        "1.4.0",
+        "1.5.0"
+      ]
     },
     "init-full": {
-      "url": "github.com/Hatchibombotar/useful-regolith-filters"
+      "url": "github.com/Hatchibombotar/useful-regolith-filters",
+      "versions": [
+        "latest",
+        "0.0.1",
+        "0.0.2",
+        "0.0.3",
+        "1.0.0",
+        "1.1.0",
+        "1.1.1",
+        "1.1.2",
+        "1.1.3"
+      ]
     },
     "link_manifests": {
-      "url": "github.com/Hatchibombotar/useful-regolith-filters"
+      "url": "github.com/Hatchibombotar/useful-regolith-filters",
+      "versions": [
+        "latest",
+        "0.0.1"
+      ]
     },
     "molang_insert": {
-      "url": "github.com/Hatchibombotar/useful-regolith-filters"
+      "url": "github.com/Hatchibombotar/useful-regolith-filters",
+      "versions": [
+        "latest",
+        "0.0.1"
+      ]
     },
     "pack_commons": {
-      "url": "github.com/Hatchibombotar/useful-regolith-filters"
+      "url": "github.com/Hatchibombotar/useful-regolith-filters",
+      "versions": [
+        "latest",
+        "0.0.1",
+        "1.0.0",
+        "1.0.1"
+      ]
     },
     "simple_blocks": {
-      "url": "github.com/Hatchibombotar/useful-regolith-filters"
+      "url": "github.com/Hatchibombotar/useful-regolith-filters",
+      "versions": [
+        "latest",
+        "0.0.1"
+      ]
     },
     "templater": {
-      "url": "github.com/Hatchibombotar/useful-regolith-filters"
+      "url": "github.com/Hatchibombotar/useful-regolith-filters",
+      "versions": [
+        "latest",
+        "0.0.1",
+        "1.0.0",
+        "1.0.1",
+        "1.0.2",
+        "2.0.0"
+      ]
     },
     "command_lang": {
-      "url": "github.com/MCDevKit/regolith-library"
+      "url": "github.com/MCDevKit/regolith-library",
+      "versions": [
+        "latest",
+        "1.0.0"
+      ]
     },
     "json_templating_engine": {
-      "url": "github.com/MCDevKit/regolith-library"
+      "url": "github.com/MCDevKit/regolith-library",
+      "versions": [
+        "latest",
+        "1.1.0",
+        "1.2.0",
+        "1.2.1",
+        "1.2.2",
+        "1.2.3",
+        "1.2.4",
+        "1.2.5",
+        "1.3.0",
+        "1.3.1",
+        "1.3.2",
+        "1.4.0",
+        "1.4.1",
+        "1.4.2",
+        "1.4.3",
+        "1.4.4",
+        "1.4.5",
+        "1.4.6",
+        "1.4.7",
+        "1.5.0",
+        "1.5.1",
+        "1.5.2"
+      ]
     },
     "jsonte": {
-      "url": "github.com/MCDevKit/regolith-library"
+      "url": "github.com/MCDevKit/regolith-library",
+      "versions": [
+        "latest",
+        "2.0.0",
+        "2.0.1",
+        "2.0.2",
+        "2.0.3",
+        "2.0.4",
+        "2.0.5",
+        "2.0.6",
+        "2.1.0",
+        "2.1.1",
+        "2.10.0",
+        "2.10.1",
+        "2.2.0",
+        "2.3.0",
+        "2.3.1",
+        "2.3.2",
+        "2.4.0",
+        "2.4.1",
+        "2.4.2",
+        "2.4.3",
+        "2.4.5",
+        "2.4.6",
+        "2.5.0",
+        "2.6.0",
+        "2.6.1",
+        "2.6.2",
+        "2.7.0",
+        "2.7.1",
+        "2.8.0",
+        "2.8.1",
+        "2.8.2",
+        "2.8.3",
+        "2.9.0",
+        "2.9.1",
+        "2.9.2",
+        "2.9.3",
+        "2.9.4",
+        "2.9.5"
+      ]
     },
     "esbuild_executor": {
-      "url": "github.com/MajestikButter/Regolith-Filters"
+      "url": "github.com/MajestikButter/Regolith-Filters",
+      "versions": [
+        "latest"
+      ]
     },
     "js_formatter": {
-      "url": "github.com/MajestikButter/Regolith-Filters"
+      "url": "github.com/MajestikButter/Regolith-Filters",
+      "versions": [
+        "latest"
+      ]
     },
     "json_formatter": {
-      "url": "github.com/MajestikButter/Regolith-Filters"
+      "url": "github.com/MajestikButter/Regolith-Filters",
+      "versions": [
+        "latest"
+      ]
     },
     "ts_transpiler": {
-      "url": "github.com/MajestikButter/Regolith-Filters"
+      "url": "github.com/MajestikButter/Regolith-Filters",
+      "versions": [
+        "latest"
+      ]
     },
     "export": {
-      "url": "github.com/Makercamp-SRLs/Regolith-filters"
+      "url": "github.com/Makercamp-SRLs/Regolith-filters",
+      "versions": [
+        "latest"
+      ]
     },
     "digger": {
-      "url": "github.com/MedicalJewel105/regolilters"
+      "url": "github.com/MedicalJewel105/regolilters",
+      "versions": [
+        "latest",
+        "1.0.0"
+      ]
     },
     "item_scale": {
-      "url": "github.com/MedicalJewel105/regolilters"
+      "url": "github.com/MedicalJewel105/regolilters",
+      "versions": [
+        "latest"
+      ]
     },
     "custom_project": {
-      "url": "github.com/Nusiq/regolith-filters"
+      "url": "github.com/Nusiq/regolith-filters",
+      "versions": [
+        "latest",
+        "1.0.0",
+        "1.0.1"
+      ]
     },
     "debug_say_function_name": {
-      "url": "github.com/Nusiq/regolith-filters"
+      "url": "github.com/Nusiq/regolith-filters",
+      "versions": [
+        "latest",
+        "1.0.0",
+        "2.0.0"
+      ]
     },
     "pytemplate": {
-      "url": "github.com/Nusiq/regolith-filters"
+      "url": "github.com/Nusiq/regolith-filters",
+      "versions": [
+        "latest",
+        "0.0.1",
+        "0.0.2",
+        "1.0.0",
+        "1.1.0",
+        "1.1.1",
+        "1.1.2"
+      ]
     },
     "run_counter": {
-      "url": "github.com/Nusiq/regolith-filters"
+      "url": "github.com/Nusiq/regolith-filters",
+      "versions": [
+        "latest",
+        "1.0.0",
+        "1.0.1",
+        "1.0.2"
+      ]
     },
     "subfunctions": {
-      "url": "github.com/Nusiq/regolith-filters"
+      "url": "github.com/Nusiq/regolith-filters",
+      "versions": [
+        "latest",
+        "1.0.0",
+        "1.0.1",
+        "1.0.2",
+        "1.0.3",
+        "1.0.4",
+        "1.0.5",
+        "1.0.6",
+        "1.0.7",
+        "2.0.0",
+        "2.0.1",
+        "2.0.2",
+        "2.0.3"
+      ]
     },
     "system_template": {
-      "url": "github.com/Nusiq/regolith-filters"
+      "url": "github.com/Nusiq/regolith-filters",
+      "versions": [
+        "latest",
+        "0.0.1",
+        "0.0.2",
+        "0.0.3",
+        "1.0.0",
+        "1.1.0",
+        "1.1.1",
+        "1.2.0",
+        "2.0.0",
+        "2.0.1",
+        "2.0.2",
+        "2.1.0",
+        "2.2.0",
+        "2.3.0",
+        "2.4.0",
+        "2.4.1",
+        "2.5.0",
+        "2.6.0",
+        "2.6.1",
+        "2.7.0",
+        "2.8.0"
+      ]
     },
     "module_importer": {
-      "url": "github.com/ShiCheng-Lu/Regolith-Filters"
+      "url": "github.com/ShiCheng-Lu/Regolith-Filters",
+      "versions": [
+        "latest"
+      ]
     },
     "echo": {
-      "url": "github.com/SirLich/echo-npc-regolith"
+      "url": "github.com/SirLich/echo-npc-regolith",
+      "versions": [
+        "latest"
+      ]
     },
     "digger_gen": {
-      "url": "github.com/SirLich/regolith-filters"
+      "url": "github.com/SirLich/regolith-filters",
+      "versions": [
+        "latest",
+        "1.0.0",
+        "1.0.1"
+      ]
     },
     "particulate": {
-      "url": "github.com/SirLich/regolith-filters"
+      "url": "github.com/SirLich/regolith-filters",
+      "versions": [
+        "latest"
+      ]
     },
     "NBTEnchant": {
-      "url": "github.com/SmokeyStack/MCScripts"
+      "url": "github.com/SmokeyStack/MCScripts",
+      "versions": [
+        "latest"
+      ]
     },
     "e-backup": {
-      "url": "github.com/cda94581/regolith-filters"
+      "url": "github.com/cda94581/regolith-filters",
+      "versions": [
+        "latest",
+        "0.0.1",
+        "0.0.2"
+      ]
     },
     "minimize": {
-      "url": "github.com/cda94581/regolith-filters"
+      "url": "github.com/cda94581/regolith-filters",
+      "versions": [
+        "latest",
+        "0.0.2",
+        "0.0.3",
+        "0.0.4"
+      ]
     },
     "namespace": {
-      "url": "github.com/cda94581/regolith-filters"
+      "url": "github.com/cda94581/regolith-filters",
+      "versions": [
+        "latest",
+        "0.0.4",
+        "0.0.5",
+        "0.0.6",
+        "0.0.7"
+      ]
     },
     "scalable-teams": {
-      "url": "github.com/cda94581/regolith-premade-addons"
+      "url": "github.com/cda94581/regolith-premade-addons",
+      "versions": [
+        "latest",
+        "1.0.0",
+        "1.0.1"
+      ]
     },
     "classes": {
-      "url": "github.com/evilguy50/my-regolith-filters"
+      "url": "github.com/evilguy50/my-regolith-filters",
+      "versions": [
+        "latest",
+        "1.0.0"
+      ]
     },
     "dash": {
-      "url": "github.com/evilguy50/my-regolith-filters"
+      "url": "github.com/evilguy50/my-regolith-filters",
+      "versions": [
+        "latest",
+        "1.0.0",
+        "1.1.0",
+        "1.1.1",
+        "1.2.0"
+      ]
     },
     "ds_store": {
-      "url": "github.com/evilguy50/my-regolith-filters"
+      "url": "github.com/evilguy50/my-regolith-filters",
+      "versions": [
+        "latest",
+        "1.0.0"
+      ]
     },
     "new_exec": {
-      "url": "github.com/evilguy50/my-regolith-filters"
+      "url": "github.com/evilguy50/my-regolith-filters",
+      "versions": [
+        "latest",
+        "1.0.0",
+        "1.0.1",
+        "1.0.2",
+        "1.0.3",
+        "1.0.4",
+        "1.0.5",
+        "1.0.6",
+        "1.0.7"
+      ]
     },
     "shorthand": {
-      "url": "github.com/evilguy50/my-regolith-filters"
+      "url": "github.com/evilguy50/my-regolith-filters",
+      "versions": [
+        "latest",
+        "1.0.0"
+      ]
     },
     "strip": {
-      "url": "github.com/evilguy50/my-regolith-filters"
+      "url": "github.com/evilguy50/my-regolith-filters",
+      "versions": [
+        "latest",
+        "1.0.0"
+      ]
     },
     "style_lint": {
-      "url": "github.com/evilguy50/my-regolith-filters"
+      "url": "github.com/evilguy50/my-regolith-filters",
+      "versions": [
+        "latest",
+        "1.0.0",
+        "1.0.1",
+        "1.0.2",
+        "1.0.3"
+      ]
     },
     "title_ui": {
-      "url": "github.com/evilguy50/my-regolith-filters"
+      "url": "github.com/evilguy50/my-regolith-filters",
+      "versions": [
+        "latest",
+        "1.0.0"
+      ]
     },
     "lazuli": {
-      "url": "github.com/ink0rr/regolith-filters"
+      "url": "github.com/ink0rr/regolith-filters",
+      "versions": [
+        "latest",
+        "0.0.1",
+        "0.0.2",
+        "0.0.3",
+        "0.0.4"
+      ]
     },
     "extend-vanilla-entities": {
-      "url": "github.com/littlechestnutgames/regolith-filters"
+      "url": "github.com/littlechestnutgames/regolith-filters",
+      "versions": [
+        "latest"
+      ]
     },
     "spawn_egg": {
-      "url": "github.com/ink0rr/regolith-filters"
+      "url": "github.com/ink0rr/regolith-filters",
+      "versions": [
+        "latest",
+        "0.0.1"
+      ]
     },
     "sync_manifest": {
-      "url": "github.com/ink0rr/regolith-filters"
+      "url": "github.com/ink0rr/regolith-filters",
+      "versions": [
+        "latest"
+      ]
     },
     "swc": {
       "url": "github.com/ink0rr/regolith-filters"
     },
     "package": {
-      "url": "github.com/Hatchibombotar/useful-regolith-filters"
+      "url": "github.com/Hatchibombotar/useful-regolith-filters",
+      "versions": [
+        "latest",
+        "1.0.0",
+        "1.0.1"
+      ]
     },
     "janitor": {
-      "url": "github.com/ink0rr/regolith-filters"
+      "url": "github.com/ink0rr/regolith-filters",
+      "versions": [
+        "latest",
+        "0.0.1"
+      ]
     },
     "mcdef_gen": {
-      "url": "github.com/MCDevKit/regolith-library"
+      "url": "github.com/MCDevKit/regolith-library",
+      "versions": [
+        "latest",
+        "1.0.0",
+        "1.0.1"
+      ]
     },
     "adk": {
-      "url": "github.com/SmokeyStack/adk"
+      "url": "github.com/SmokeyStack/adk",
+      "versions": [
+        "latest",
+        "0.10.0",
+        "0.11.0",
+        "0.11.1",
+        "0.11.2",
+        "0.11.3",
+        "0.2.0",
+        "0.3.0",
+        "0.3.1",
+        "0.4.0",
+        "0.5.0",
+        "0.6.0",
+        "0.7.0",
+        "0.7.1",
+        "0.7.2",
+        "0.8.0",
+        "0.8.1",
+        "0.8.2",
+        "0.8.3",
+        "0.8.4",
+        "0.9.0"
+      ]
     },
     "rego-level": {
-      "url": "github.com/llgava/regolith-filters"
+      "url": "github.com/llgava/regolith-filters",
+      "versions": [
+        "latest",
+        "1.0.0"
+      ]
     },
     "rego-remover": {
-      "url": "github.com/llgava/regolith-filters"
+      "url": "github.com/llgava/regolith-filters",
+      "versions": [
+        "latest",
+        "1.0.0",
+        "1.1.0",
+        "1.1.1"
+      ]
     },
     "rego-glyph": {
-      "url": "github.com/llgava/regolith-filters"
+      "url": "github.com/llgava/regolith-filters",
+      "versions": [
+        "latest"
+      ]
     },
     "json_template": {
-      "url": "github.com/Nusiq/regolith-filters"
+      "url": "github.com/Nusiq/regolith-filters",
+      "versions": [
+        "latest",
+        "1.0.0",
+        "2.0.0",
+        "2.0.1",
+        "2.1.0"
+      ]
     },
     "whisk": {
-      "url": "github.com/MCDevKit/regolith-library"
+      "url": "github.com/MCDevKit/regolith-library",
+      "versions": [
+        "latest",
+        "1.0.0",
+        "1.0.1"
+      ]
     },
     "json_convert": {
-      "url": "github.com/Bedrock-OSS/regolith-filters"
+      "url": "github.com/Bedrock-OSS/regolith-filters",
+      "versions": [
+        "latest",
+        "1.0.0"
+      ]
     },
     "cda94581_export": {
-      "url": "github.com/cda94581/regolith-filters"
+      "url": "github.com/cda94581/regolith-filters",
+      "versions": [
+        "latest",
+        "0.0.2",
+        "0.0.3"
+      ]
     }
   }
 }

--- a/scraper.nim
+++ b/scraper.nim
@@ -11,11 +11,13 @@ type
         name: string
         author: string
         url: string
+        versions: seq[string]
 
-proc newFilter(name, author, url: string): Filter =
+proc newFilter(name, author, url: string, versions: seq[string]): Filter =
     result.name = name
     result.author = author
     result.url = url
+    result.versions = versions
 
 proc findRepo(author, repoName: string): string =
     for repo in repoList["known_repos"].to(seq[string]):
@@ -28,35 +30,52 @@ proc cloneRepos() =
     setCurrentDir("Repos")
     for repo in repoList["known_repos"].to(seq[string]):
         let cloneSplit = repo.split("/")
-        var cloneName = ""
-        if cloneSplit[0].startsWith("github.com"):
-            cloneName = cloneSplit[1] & "/" & cloneSplit[2]
+        let cloneName = cloneSplit[1] & "/" & cloneSplit[2]
         let cloneUrl = "http://" & repo
         if not dirExists(cloneName):
             discard execShellCmd(fmt"git clone {cloneUrl} {cloneName}")
     setCurrentDir(getAppDir())
 
 iterator getFilters(): Filter =
+    let root = getCurrentDir()
     for owner in walkDir("Repos"):
         let user = splitPath(owner.path)[1]
         for repo in walkDir(owner.path):
             let repoName = splitPath(repo.path)[1]
-            for filter in walkDir(repo.path):
+            setCurrentDir(root & "/" & repo.path)
+            discard execShellCmd("git tag > tags.txt")
+            for filter in walkDir(getCurrentDir()):
                 let filterName = splitPath(filter.path)[1]
                 if (fileExists(filter.path & "/filter.json")):
-                    yield newFilter(filterName, user, findRepo(user, repoName))
+                    var versions: seq[string] = @["latest"]
+                    let tagList = readFile("tags.txt").split("\n")
+                    for tag in tagList:
+                        if tag.contains(filterName):
+                            let strVersion = tag.replace(filterName & "-", "")
+                            versions.add(strVersion)
+                    yield newFilter(filterName, user, findRepo(user, repoName), versions)
+            setCurrentDir(root)
 
-proc addFilter(f: Filter) =
+proc addFilter(f: Filter): Filter =
+    result = f
     if not resolverJson["filters"].hasKey(f.name):
-        resolverJson["filters"][f.name] = %*{"url": f.url}
+        resolverJson["filters"][f.name] = %*{"url": f.url, "versions": f.versions}
         echo fmt"Added filter {f.name}"
     elif not resolverJson["filters"][f.name]["url"].to(string).contains(f.author):
         let newFilterName = f.author & "_" & f.name
-        resolverJson["filters"][newFilterName] = %*{"url": f.url}
-        echo fmt"Added filter {newFilterName}"
+        if not resolverJson["filters"].hasKey(newFilterName):
+            resolverJson["filters"][newFilterName] = %*{"url": f.url, "versions": f.versions}
+            echo fmt"Added filter {newFilterName}"
+        result.name = newFilterName
 
 cloneRepos()
+var allFilters: seq[Filter] = @[]
 for validFilter in getFilters():
-    validFilter.addFilter()
+    let addedFilter = validFilter.addFilter()
+    allFilters.add(addedFilter)
+
+for existFilter in allFilters:
+    resolverJson["filters"][existFilter.name]["versions"] = %*existFilter.versions
+
 resolverJsonPath.writeFile(resolverJson.pretty())
 sleep(1500)

--- a/scraper.nim
+++ b/scraper.nim
@@ -1,75 +1,62 @@
-import os, json, strutils, strformat, httpclient
+import std/[os, json, strutils, strformat]
 
-var 
-    client = newHttpClient()
+let
     resolverJsonPath = fmt"{getAppDir()}/resolver.json"
-    resolverJson = parseFile(resolverJsonPath)
+    repoList = parseFile("repos.json")
+
+var resolverJson = parseFile(resolverJsonPath)
 
 type
     Filter = object
         name: string
         author: string
         url: string
-        lang: string
-        desc: string
 
 proc newFilter(name, author, url: string): Filter =
     result.name = name
     result.author = author
     result.url = url
 
-proc getRepos(): JsonNode =
-    const filterReqUrl = r"https://api.github.com/search/repositories?q=topic:regolith-filter"
-    let repoRes = client.getContent(filterReqUrl)
-    return repoRes.parseJson()
+proc findRepo(author, repoName: string): string =
+    for repo in repoList["known_repos"].to(seq[string]):
+        if repo.contains(author) and repo.contains(repoName):
+            return repo
+    quit("Unable to run findRepo")
 
-proc cloneRepos(repoList: JsonNode) =
+proc cloneRepos() =
     createDir("Repos")
     setCurrentDir("Repos")
-    for repo in repoList["items"]:
-        let cloneName = repo["full_name"].to(string).replace("/", "___")
-        let cloneUrl = repo["clone_url"].to(string)
+    for repo in repoList["known_repos"].to(seq[string]):
+        let cloneSplit = repo.split("/")
+        var cloneName = ""
+        if cloneSplit[0].startsWith("github.com"):
+            cloneName = cloneSplit[1] & "/" & cloneSplit[2]
+        let cloneUrl = "http://" & repo
         if not dirExists(cloneName):
             discard execShellCmd(fmt"git clone {cloneUrl} {cloneName}")
     setCurrentDir(getAppDir())
 
-proc isFilter(relativeDir: string): bool =
-    let checkRoot = getCurrentDir()
-    setCurrentDir(relativeDir)
-    result = fileExists("filter.json")
-    setCurrentDir(checkRoot)
-
-proc getFilters(): seq[Filter] =
-    setCurrentDir("Repos")
-    var filterList: seq[Filter] = @[]
-    let repoRoot = getCurrentDir()
-    for repo in walkPattern("**"):
-        setCurrentDir(repoRoot)
-        let 
-            repoOwner = repo.split("___")[0]
-            repoName = repo.split("___")[1]
-        var repoUrl = fmt"github.com/{repoOwner}/{repoName}"
-        echo fmt"Looking through repo {repoUrl}"
-        if isFilter(repo):
-            filterList.add(newFilter(repoName, repoOwner, repoUrl))
-            continue
-        setCurrentDir(repo)
-        for filter in walkDirs("*"):
-            if isFilter(filter):
-                filterList.add(newFilter(filter, repoOwner, repoUrl))
-        
-    setCurrentDir(getAppDir())
-    return filterList
+iterator getFilters(): Filter =
+    for owner in walkDir("Repos"):
+        let user = splitPath(owner.path)[1]
+        for repo in walkDir(owner.path):
+            let repoName = splitPath(repo.path)[1]
+            for filter in walkDir(repo.path):
+                let filterName = splitPath(filter.path)[1]
+                if (fileExists(filter.path & "/filter.json")):
+                    yield newFilter(filterName, user, findRepo(user, repoName))
 
 proc addFilter(f: Filter) =
     if not resolverJson["filters"].hasKey(f.name):
         resolverJson["filters"][f.name] = %*{"url": f.url}
         echo fmt"Added filter {f.name}"
+    elif not resolverJson["filters"][f.name]["url"].to(string).contains(f.author):
+        let newFilterName = f.author & "_" & f.name
+        resolverJson["filters"][newFilterName] = %*{"url": f.url}
+        echo fmt"Added filter {newFilterName}"
 
-let repoList = getRepos()
-cloneRepos(repoList)
-let filterList: seq[Filter] = getFilters()
-for f in filterList:
-    addFilter(f)
+cloneRepos()
+for validFilter in getFilters():
+    validFilter.addFilter()
 resolverJsonPath.writeFile(resolverJson.pretty())
 sleep(1500)


### PR DESCRIPTION
The resolver will now loop over repos defined in repos.json["known_repos"] instead of accessing githubs api to look for repos tagged with regolith-filter.
This change was made to address issues brought up in #9 

The resolver also now keeps track of tagged versions to make it easier for regolith to add update messages 
